### PR TITLE
examples: Use the libcoap logging definitions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2021 obgm
+Copyright (c) 2018-2023 obgm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for libcoap minimal examples
 #
-# Copyright (C) 2018-2021 Olaf Bergmann <bergmann@tzi.org>
+# Copyright (C) 2018-2023 Olaf Bergmann <bergmann@tzi.org>
 #
 
 LIBCOAP?=libcoap-3

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ response.
 `server.cc` is a minimal CoAP UDP server that binds on
 `localhost:5683`. It has a single resource `/hello`.
 
-Copyright (C) 2018-2021 Olaf Bergmann <bergmann@tzi.org>
+Copyright (C) 2018-2023 Olaf Bergmann <bergmann@tzi.org>
 
 License
 =======

--- a/client.cc
+++ b/client.cc
@@ -1,6 +1,6 @@
 /* minimal CoAP client
  *
- * Copyright (C) 2018-2021 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2018-2023 Olaf Bergmann <bergmann@tzi.org>
  */
 
 #include <cstring>
@@ -22,17 +22,17 @@ main(void) {
   coap_startup();
 
   /* Set logging level */
-  coap_set_log_level(LOG_WARNING);
+  coap_set_log_level(COAP_LOG_WARN);
 
   /* resolve destination address where server should be sent */
   if (resolve_address("coap.me", "5683", &dst) < 0) {
-    coap_log(LOG_CRIT, "failed to resolve address\n");
+    coap_log_crit("failed to resolve address\n");
     goto finish;
   }
 
   /* create CoAP context and a client session */
   if (!(ctx = coap_new_context(nullptr))) {
-    coap_log(LOG_EMERG, "cannot create libcoap context\n");
+    coap_log_emerg("cannot create libcoap context\n");
     goto finish;
   }
   /* Support large responses */
@@ -41,7 +41,7 @@ main(void) {
 
   if (!(session = coap_new_client_session(ctx, nullptr, &dst,
                                                   COAP_PROTO_UDP))) {
-    coap_log(LOG_EMERG, "cannot create client session\n");
+    coap_log_emerg("cannot create client session\n");
     goto finish;
   }
 
@@ -50,7 +50,7 @@ main(void) {
                                          const coap_pdu_t *received,
                                          auto) {
                                         have_response = 1;
-                                        coap_show_pdu(LOG_WARNING, received);
+                                        coap_show_pdu(COAP_LOG_WARN, received);
                                         return COAP_RESPONSE_OK;
                                       });
   /* construct CoAP message */
@@ -59,7 +59,7 @@ main(void) {
                       coap_new_message_id(session),
                       coap_session_max_pdu_size(session));
   if (!pdu) {
-    coap_log( LOG_EMERG, "cannot create PDU\n" );
+    coap_log_emerg("cannot create PDU\n" );
     goto finish;
   }
 
@@ -67,7 +67,7 @@ main(void) {
   coap_add_option(pdu, COAP_OPTION_URI_PATH, 5,
                   reinterpret_cast<const uint8_t *>("hello"));
 
-  coap_show_pdu(LOG_WARNING, pdu);
+  coap_show_pdu(COAP_LOG_WARN, pdu);
   /* and send the PDU */
   coap_send(session, pdu);
 

--- a/common.cc
+++ b/common.cc
@@ -1,6 +1,6 @@
 /* minimal CoAP functions
  *
- * Copyright (C) 2018-2021 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2018-2023 Olaf Bergmann <bergmann@tzi.org>
  */
 
 #include <cstdio>

--- a/common.hh
+++ b/common.hh
@@ -1,6 +1,6 @@
 /* minimal CoAP functions
  *
- * Copyright (C) 2018-2021 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2018-2023 Olaf Bergmann <bergmann@tzi.org>
  */
 
 #include <coap3/coap.h>

--- a/server.cc
+++ b/server.cc
@@ -1,6 +1,6 @@
 /* minimal CoAP server
  *
- * Copyright (C) 2018-2021 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2018-2023 Olaf Bergmann <bergmann@tzi.org>
  */
 
 #include <cstring>
@@ -21,7 +21,7 @@ main(void) {
 
   /* resolve destination address where server should be sent */
   if (resolve_address("localhost", "5683", &dst) < 0) {
-    coap_log(LOG_CRIT, "failed to resolve address\n");
+    coap_log_crit("failed to resolve address\n");
     goto finish;
   }
 
@@ -29,7 +29,7 @@ main(void) {
   ctx = coap_new_context(nullptr);
 
   if (!ctx || !(endpoint = coap_new_endpoint(ctx, &dst, COAP_PROTO_UDP))) {
-    coap_log(LOG_EMERG, "cannot initialize context\n");
+    coap_log_emerg("cannot initialize context\n");
     goto finish;
   }
 
@@ -39,11 +39,11 @@ main(void) {
                            const coap_pdu_t *request,
                            auto,
                            coap_pdu_t *response) {
-                          coap_show_pdu(LOG_WARNING, request);
+                          coap_show_pdu(COAP_LOG_WARN, request);
                           coap_pdu_set_code(response, COAP_RESPONSE_CODE_CONTENT);
                           coap_add_data(response, 5,
                                         (const uint8_t *)"world");
-                          coap_show_pdu(LOG_WARNING, response);
+                          coap_show_pdu(COAP_LOG_WARN, response);
                         });
   coap_add_resource(ctx, resource);
 


### PR DESCRIPTION
[As added in post 4.3.1]

Update Copyright dates at the same time.